### PR TITLE
Modify pre-filter section in the scheduling framework

### DIFF
--- a/keps/sig-scheduling/20180409-scheduling-framework.md
+++ b/keps/sig-scheduling/20180409-scheduling-framework.md
@@ -176,8 +176,14 @@ plugin may be enabled at a time.
 ### Pre-filter
 
 These plugins are used to pre-process info about the pod, or to check certain
-conditions that the cluster or the pod must meet. If a pre-filter plugin returns
-an error, the scheduling cycle is aborted.
+conditions that the cluster or the pod must meet. A pre-filter plugin should implement
+a PreFilter function, if PreFilter returns an error, the scheduling cycle is aborted.
+
+A Pre-filter plugin can provide another two optional functions: **AddPod** and **RemovePod** 
+to incrementally modify its pre-processed info. The framework guarantees that those
+functions will only be called after PreFilter. The framework may call those functions 
+more than once before calling Filter on a specific node.
+
 
 ### Filter
 


### PR DESCRIPTION
This is based on the possible outcome of https://github.com/kubernetes/kubernetes/issues/82897, which suggest that we may need to allow pre-filter plugins to define Add/RemovePod APIs for incremental state updates.